### PR TITLE
fix(supervisor): fix update heartbeat

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -153,6 +153,7 @@ func (c *WorkloadsController) calculateClusterUtilization() {
 // RunCalculationLoop Run the cluster calculation loop every minute
 func (c *WorkloadsController) RunCalculationLoop() {
 	for {
+		supervisor.UpdateHeartbeat()
 		c.clearPodsList()
 		c.addPodsToNodes()
 		c.calculateTotalPodsMetrics()

--- a/pkg/supervisor/handle.go
+++ b/pkg/supervisor/handle.go
@@ -27,6 +27,10 @@ type Handler struct {
 	MaxLoopTime time.Duration
 }
 
+func UpdateHeartbeat() {
+	Heartbeat = time.Now()
+}
+
 func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	if !Healthy || Heartbeat.Add(h.MaxLoopTime).Before(time.Now()) {
 		zap.S().Errorw("liveness failed", "healthy", Healthy, "heartbeat", Heartbeat, "maxLoopTime", h.MaxLoopTime)


### PR DESCRIPTION
Fix an issue where the heartbeat update wasn't performed regularly, leading to the liveness probe killing the application